### PR TITLE
add snackbars when requesting a mock interview

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "web-vitals": "^1.0.1"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "BROWSER=brave react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/src/components/Interviewee/Schedule/IntervieweeSchedule.tsx
+++ b/src/components/Interviewee/Schedule/IntervieweeSchedule.tsx
@@ -1,5 +1,5 @@
 import UIMainContainer from 'components/UI/UIBoxContainer';
-import React from 'react';
+import React, { useState } from 'react';
 import InfoIcon from '@material-ui/icons/Info';
 import {
   CREATE_ACTION,
@@ -26,22 +26,66 @@ import AddIcon from '@material-ui/icons/Add';
 import DeleteIcon from '@material-ui/icons/Delete';
 import { DatePicker, MuiPickersUtilsProvider } from '@material-ui/pickers';
 import CardContent from '@material-ui/core/CardContent';
+import Snackbar from '@material-ui/core/Snackbar';
+import MuiAlert from '@material-ui/lab/Alert';
+import { useEffect } from 'react';
+
+function Alert(props: any) {
+  return <MuiAlert elevation={6} variant="filled" {...props} />;
+}
 
 const IntervieweeSchedule: React.FC<IntervieweeScheduleProps> = ({
   copy,
   interviewInformationFields,
   intervieweeAvaliabilityFields,
   enterToPoolMutation,
+  isLoading,
 }) => {
+  const [successSnackBarOpen, setSuccessSnackBarOpen] = useState(false);
+  const [failSnackBarOpen, setFailSnackBarOpen] = useState(false);
+  const [loadingSnackBarOpen, setLoadingSnackBarOpen] = useState(false);
+
+  useEffect(() => {
+    if (isLoading) {
+      setLoadingSnackBarOpen(true);
+    } else {
+      setLoadingSnackBarOpen(false);
+    }
+  }, [isLoading]);
   return (
     <UIMainContainer>
+      <Snackbar open={loadingSnackBarOpen}>
+        <Alert severity="info">Loading...</Alert>
+      </Snackbar>
+      <Snackbar
+        open={successSnackBarOpen}
+        autoHideDuration={6000}
+        onClose={() => setSuccessSnackBarOpen(false)}
+      >
+        <Alert severity="success">
+          Your Request has been sent! Please keep an eye on your email for the
+          following days :)
+        </Alert>
+      </Snackbar>
+      <Snackbar
+        open={failSnackBarOpen}
+        autoHideDuration={6000}
+        onClose={() => setFailSnackBarOpen(false)}
+      >
+        <Alert severity="error">
+          An Error occurred, please try again later
+        </Alert>
+      </Snackbar>
       <Typography variant="h4">{copy.header}</Typography>
       <br />
       <form
         noValidate
         onSubmit={event => {
           event.preventDefault();
-          enterToPoolMutation();
+          enterToPoolMutation(
+            () => setSuccessSnackBarOpen(true),
+            () => setFailSnackBarOpen(true)
+          );
         }}
       >
         {interviewInformationFields.map((input, id) => {

--- a/src/screens/Interviewee/Schedule.tsx
+++ b/src/screens/Interviewee/Schedule.tsx
@@ -1,6 +1,4 @@
 import IntervieweeSchedule from 'components/Interviewee/Schedule/IntervieweeSchedule';
-import UserError from 'components/User/UserError';
-import UserLoading from 'components/User/UserLoading';
 import React, { useReducer, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { INTERVIEWEE_SCHEDULE_COPY } from 'utils/constants/copy';
@@ -81,10 +79,7 @@ const avaliabilityReducer = (
 const IntervieweeMock = () => {
   let history = useHistory();
 
-  const [
-    enterToPool,
-    { loading: enterPoolLoading, error: enterToPoolMutationError },
-  ] = useMutation(ENTER_POOL);
+  const [enterToPool, { loading: enterPoolLoading }] = useMutation(ENTER_POOL);
 
   const [interviewType, setInterviewTypeValue] = useState('');
   const [rol, setRolValue] = useState('');

--- a/src/screens/Interviewee/Schedule.tsx
+++ b/src/screens/Interviewee/Schedule.tsx
@@ -95,9 +95,6 @@ const IntervieweeMock = () => {
     0: { day: null, interval: ['', ''] },
   });
 
-  if (enterPoolLoading) return <UserLoading />;
-  if (enterToPoolMutationError) return <UserError />;
-
   const positionField: staticField = {
     label: INTERVIEWEE_SCHEDULE_COPY.form.positionLabel,
     values: Object.keys(POSITIONS),
@@ -150,11 +147,13 @@ const IntervieweeMock = () => {
     setter: dispatchAvaliability,
   };
 
-  const createMockInterview = () => {
+  const createMockInterview = (onSuccess: () => void, onFail: () => void) => {
     Data.callMutationAndRedirectToHome(
       enterToPool,
       Data.parseInputToPoolAPI(staticInputs, dynamicInputs),
-      history
+      history,
+      onSuccess,
+      onFail
     );
   };
 
@@ -164,6 +163,7 @@ const IntervieweeMock = () => {
       interviewInformationFields={staticInputs}
       intervieweeAvaliabilityFields={dynamicInputs}
       enterToPoolMutation={createMockInterview}
+      isLoading={enterPoolLoading}
     />
   );
 };

--- a/src/utils/helpers/Data.ts
+++ b/src/utils/helpers/Data.ts
@@ -13,13 +13,19 @@ export default class Data {
   static callMutationAndRedirectToHome(
     mutation: any,
     parameters: any,
-    history: any
+    history: any,
+    onSuccess: () => void,
+    onFail: () => void
   ) {
     mutation({
       variables: parameters,
     })
-      .then(() => history.push(HOME_PATH))
+      .then(() => {
+        onSuccess();
+        setTimeout(() => history.push(HOME_PATH), 1000);
+      })
       .catch((error: any) => {
+        onFail();
         console.error(error);
       });
   }

--- a/src/utils/ts/propsInterfaces.ts
+++ b/src/utils/ts/propsInterfaces.ts
@@ -15,7 +15,8 @@ export interface IntervieweeScheduleProps {
   copy: Record<string, any>;
   interviewInformationFields: Array<Record<string, any>>;
   intervieweeAvaliabilityFields: Record<string, any>;
-  enterToPoolMutation: any;
+  enterToPoolMutation: (onSuccess: () => void, onFail: () => void) => void;
+  isLoading: boolean;
 }
 
 /* Interviewer */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,13 +17,17 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "alwaysStrict": true,
-    "baseUrl": "src"
+    "baseUrl": "src",
+    "noFallthroughCasesInSwitch": true
   },
   "include": [
     "src",
-    "@types",
+    "@types"
   ],
-  "exclude": ["node_modules/clipboard-polyfill/*", "**/*.spec.ts"]
+  "exclude": [
+    "node_modules/clipboard-polyfill/*",
+    "**/*.spec.ts"
+  ]
 }


### PR DESCRIPTION
# Context

We were not showing nice messages to the user on loading, success, or errors, we were completely replacing the page with raw text in such cases

# What does this PR do?

It adds Material UI snackbars to display loading, error and success messages.

# Evidence

![image](https://user-images.githubusercontent.com/5056411/130297312-2f2f97a3-a3db-4a17-8bee-1250126aac54.png)
![image](https://user-images.githubusercontent.com/5056411/130297359-57d68e96-11c2-4fed-963c-4845f6a7de33.png)
![image](https://user-images.githubusercontent.com/5056411/130297695-f0fce566-ab67-4572-8aa9-0ca54a4cbe51.png)
