### PR TITLE
Remove extra corrupted resume being uploaded to gdrive

### DIFF
--- a/src/screens/Interviewee/Profile.tsx
+++ b/src/screens/Interviewee/Profile.tsx
@@ -7,11 +7,14 @@ import { useHistory } from 'react-router-dom';
 import { HOME_PATH } from 'routes/paths';
 import { INTERVIEWEE_PROFILE_COPY } from 'utils/constants/copy';
 import {
-    CREATE_INTERVIEWEE, UPDATE_INTERVIEWEE, UPLOAD_RESUME_TO_FOLDER_OR_UPDATE
+  CREATE_INTERVIEWEE,
+  UPDATE_INTERVIEWEE,
+  UPLOAD_RESUME_TO_FOLDER_OR_UPDATE,
 } from 'utils/constants/endpoints';
 import { SLICE_METADATA, UNIVERSITIES } from 'utils/constants/values';
 
 import { useLazyQuery, useMutation } from '@apollo/client';
+import { useEffect } from 'react';
 
 const IntervieweeEditProfile = () => {
   let history = useHistory();
@@ -63,28 +66,30 @@ const IntervieweeEditProfile = () => {
     fileReader.readAsDataURL(resume);
   };
 
-  if (uploadResumeToFolderRLoading) return <UserLoading />;
-  if (createOrUpdateIntervieweeMutationError) return <UserError />;
-
-  if (gFolderData) {
-    if (newUser) {
-      createOrUpdateInterviewee({
-        variables: {
-          information: {
-            folder: gFolderData.upload_resume_and_create_folder.id,
+  useEffect(() => {
+    if (gFolderData) {
+      if (newUser) {
+        createOrUpdateInterviewee({
+          variables: {
+            information: {
+              folder: gFolderData.upload_resume_and_create_folder.id,
+              school: school,
+            },
+          },
+        });
+      } else {
+        createOrUpdateInterviewee({
+          variables: {
             school: school,
           },
-        },
-      });
-    } else {
-      createOrUpdateInterviewee({
-        variables: {
-          school: school,
-        },
-      });
+        });
+      }
+      history.push(HOME_PATH);
     }
-    history.push(HOME_PATH);
-  }
+  }, [gFolderData, newUser, createOrUpdateInterviewee, history, school]);
+
+  if (uploadResumeToFolderRLoading) return <UserLoading />;
+  if (createOrUpdateIntervieweeMutationError) return <UserError />;
 
   return (
     <IntervieweeProfile


### PR DESCRIPTION
# Context

An extra resume was being uploaded to our backend, except that the duplicated one was corrupted. We discovered that
the frontend was sending duplicated mutations, because we were executing the upload logic on each re-render of the component.

UseEffect is a hook in charge of observing state changes of specific variables https://reactjs.org/docs/hooks-effect.html#example-using-hooks

# What does this PR do?

It fixes the issue by wrapping the logic inside a useEffect hook

# Evidence

## Before

https://user-images.githubusercontent.com/5056411/131779675-39b9120b-2b95-456e-b4a1-012667b436df.mp4

## After


https://user-images.githubusercontent.com/5056411/131779708-eb278eef-d686-4f39-9400-a08bbc6d9586.mp4


