### PR TITLE
Fix incoming and past interviews queries

### DIFF
--- a/src/screens/User/IncomingInterviews.tsx
+++ b/src/screens/User/IncomingInterviews.tsx
@@ -17,7 +17,7 @@ import { IncomingInterview } from 'utils/ts/dataTypes';
 
 import { useMutation, useQuery } from '@apollo/client';
 
-const now = DateTime.getCurrentDate();
+const now = DateTime.getCurrentDateTimeInPT();
 
 const IncomingInterviews = () => {
   const intervieweeRole = useUserRole() === UserRole[UserRole.interviewee];

--- a/src/screens/User/PastInterviews.tsx
+++ b/src/screens/User/PastInterviews.tsx
@@ -10,7 +10,7 @@ import { PastInterview } from 'utils/ts/dataTypes';
 
 import { useQuery } from '@apollo/client';
 
-const now: string = DateTime.getCurrentDate();
+const now: string = DateTime.getCurrentDateTimeInPT();
 
 const PastInterviews = () => {
   const {

--- a/src/utils/helpers/DateTime.ts
+++ b/src/utils/helpers/DateTime.ts
@@ -28,6 +28,12 @@ export default class DateTime {
     return new Date().toISOString().split('.')[0];
   }
 
+  static getCurrentDateTimeInPT(): string {
+    return new Date(
+      new Date().toLocaleString('en-US', { timeZone: 'America/Los_Angeles' }) + ' UTC'
+    ).toISOString().split('.')[0];
+  }
+
   static formatDateToDay(currentDate: Date) {
     return `${currentDate.getMonth()}/${currentDate.getDate()}/${currentDate.getFullYear()}`;
   }


### PR DESCRIPTION
# Context

Incoming interviews where shown as past interviews
due to inconsistency with timezones when making
the queries

# What does this PR do?

It fixes the queries by making them be in PT, which is same as DB.
